### PR TITLE
Feature 5 : Broadcasting & Indexing Support v1.2

### DIFF
--- a/numdrift/core.py
+++ b/numdrift/core.py
@@ -24,7 +24,7 @@ class mdarray:
         - dtype: optional, specifies the data type
         - missing_value: placeholder for missing values (default: custom object)
         """
-        self.data = np.array(data)  # Store the data
+        self.data = np.array(data, dtype=float)  # Store the data
         self.missing_value = missing_value
         
         if mask is not None:


### PR DESCRIPTION
**Fixing "ValueError: cannot convert float Nan to integer"**

**Resolution**: In the mdarray constructor, ensure that the data array is always of type float, which can handle np.nan

Forcing dtype=float: Ensures the self.data array can safely hold np.nan values, resolving the ValueError.
Preserves Masking: Continues to handle missing values via the mask array.